### PR TITLE
Bugfix - Allow same day checkout and checkin during booking

### DIFF
--- a/backend/api-service/src/main/java/at/technikum/boutique/hotel/apiservice/bookings/BookingsRepository.java
+++ b/backend/api-service/src/main/java/at/technikum/boutique/hotel/apiservice/bookings/BookingsRepository.java
@@ -15,7 +15,9 @@ public interface BookingsRepository extends JpaRepository<BookingEntity, Integer
 
     @Query(value = "SELECT b FROM BookingEntity b" +
             "    WHERE b.room.id = :#{#roomId} " +
-            "        AND b.endDate >= :#{#start} " +
-            "        AND b.startDate <= :#{#end} ")
+            "        AND b.endDate > :#{#start} " +
+            "        AND b.startDate < :#{#end} ")
     List<BookingEntity> getBookingsForRoomWithinPeriod(@Param("start") LocalDate start, @Param("end") LocalDate end, @Param("roomId") Integer roomId);
+
+
 }

--- a/backend/api-service/src/main/java/at/technikum/boutique/hotel/apiservice/rooms/RoomsRepository.java
+++ b/backend/api-service/src/main/java/at/technikum/boutique/hotel/apiservice/rooms/RoomsRepository.java
@@ -15,8 +15,8 @@ import java.time.LocalDate;
 public interface RoomsRepository extends JpaRepository<RoomEntity, Integer>, JpaSpecificationExecutor<RoomEntity> {
 
     @Query(value = "SELECT r FROM RoomEntity r LEFT OUTER JOIN  BookingEntity b ON r.id = b.room.id " +
-            "AND b.endDate >= :#{#start} " +
-            "AND b.startDate <= :#{#end} " +
+            "AND b.endDate > :#{#start} " +
+            "AND b.startDate < :#{#end} " +
             "WHERE b.room IS NULL"
     )
     Page<RoomEntity> findAllAvailableRooms(@Param("start") LocalDate availabilityPeriodStart, @Param("end") LocalDate availabilityPeriodEnd, Pageable pageable);


### PR DESCRIPTION
Allow same day checkout and checkin during booking and reflect this change on availability endpoints

- [x] If a booking exist from `2024-01-01` to `2024-01-05` a booking between `2024-01-05` and some date in the future should be possible.
- [x] This change should be reflected on the  `GET /api/v1/rooms/:roomId/booked` endpoint
- [x] This change should be reflected on the  `GET /api/v1/rooms/available` endpoint